### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow that builds and tests on pushes to `main` and for pull requests

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686709c5427883318c7ba81296a49f30