### PR TITLE
Add output file summary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use vfs::VfsPath;
 
 pub mod output;
-pub use output::{graph_to_dot, graph_to_json};
+pub use output::{filter_graph, graph_to_dot, graph_to_json};
 pub mod types;
 use types::package_json::{PackageDepsParser, PackageMainParser};
 mod analysis;
@@ -27,6 +27,20 @@ pub enum NodeKind {
     Folder,
     Asset,
     Package,
+}
+
+impl std::fmt::Display for NodeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            NodeKind::File => "file",
+            NodeKind::External => "external",
+            NodeKind::Builtin => "builtin",
+            NodeKind::Folder => "folder",
+            NodeKind::Asset => "asset",
+            NodeKind::Package => "package",
+        };
+        write!(f, "{}", name)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,16 @@ enum OutputFormat {
     Json,
 }
 
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            OutputFormat::Dot => "dot",
+            OutputFormat::Json => "json",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 #[derive(Parser)]
 #[command(
     name = "dep",
@@ -81,24 +91,42 @@ fn main() -> anyhow::Result<()> {
             color: args.color,
         },
     )?;
+    let filtered = dep::filter_graph(
+        &graph,
+        args.include_external,
+        args.include_builtins,
+        args.include_folders,
+        args.include_assets,
+        args.include_packages,
+    );
+    use dep::NodeKind;
+    use petgraph::visit::EdgeRef;
+    use std::collections::HashMap;
+    let mut counts: HashMap<NodeKind, (usize, usize)> = HashMap::new();
+    for idx in filtered.node_indices() {
+        let kind = filtered[idx].kind.clone();
+        counts.entry(kind).or_default().0 += 1;
+    }
+    for e in filtered.edge_references() {
+        let kind = filtered[e.source()].kind.clone();
+        counts.entry(kind).or_default().1 += 1;
+    }
     let output_str = match args.format {
-        OutputFormat::Dot => dep::graph_to_dot(
-            &graph,
-            args.include_external,
-            args.include_builtins,
-            args.include_folders,
-            args.include_assets,
-            args.include_packages,
-        ),
-        OutputFormat::Json => dep::graph_to_json(
-            &graph,
-            args.include_external,
-            args.include_builtins,
-            args.include_folders,
-            args.include_assets,
-            args.include_packages,
-        ),
+        OutputFormat::Dot => dep::graph_to_dot(&filtered),
+        OutputFormat::Json => dep::graph_to_json(&filtered),
     };
-    std::fs::write(&args.output, output_str)?;
+    std::fs::write(&args.output, &output_str)?;
+    println!("Saving {} file {}", args.format, args.output.display());
+    for kind in &[
+        NodeKind::File,
+        NodeKind::External,
+        NodeKind::Builtin,
+        NodeKind::Folder,
+        NodeKind::Asset,
+        NodeKind::Package,
+    ] {
+        let (nodes, edges) = counts.get(kind).cloned().unwrap_or((0, 0));
+        println!("{}: {} nodes & {} edges", kind, nodes, edges);
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- export a `filter_graph` helper
- compute node and edge counts and print them after writing output
- refine output with two lines summarizing counts by `NodeKind`
- implement Display for `NodeKind` to clean up count reporting

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68670f619b00833180ee0c76c933e457