### PR TITLE
Add recursive gitignore support with property test

### DIFF
--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -6,19 +6,46 @@ use crate::types::html::HTML_EXTENSIONS;
 use crate::types::js::JS_EXTENSIONS;
 const SPECIAL_FILES: &[&str] = &["package.json", "pnpm-workspace.yml", "tsconfig.json"];
 
-fn load_gitignore(root: &VfsPath) -> anyhow::Result<Option<Gitignore>> {
-    if let Ok(path) = root.join(".gitignore") {
-        if path.exists()? {
+struct GitIgnoreEntry {
+    prefix: String,
+    gi: Gitignore,
+}
+
+fn load_gitignore(root: &VfsPath) -> anyhow::Result<Vec<GitIgnoreEntry>> {
+    let mut entries = Vec::new();
+    let walk = match root.walk_dir() {
+        Ok(w) => w,
+        Err(_) => return Ok(entries),
+    };
+
+    let root_str = root.as_str().trim_end_matches('/');
+
+    for entry in walk {
+        let path = entry?;
+        if path
+            .as_str()
+            .rsplit_once('/')
+            .map(|(_, name)| name == ".gitignore")
+            .unwrap_or(false)
+        {
+            let dir = Path::new(path.as_str()).parent().unwrap_or(Path::new(""));
+            let prefix = dir
+                .to_str()
+                .unwrap_or("")
+                .trim_start_matches(root_str)
+                .trim_start_matches('/')
+                .to_string();
             let contents = path.read_to_string()?;
-            let mut builder = GitignoreBuilder::new("");
+            let mut builder = GitignoreBuilder::new(dir);
             for line in contents.lines() {
                 let _ = builder.add_line(None, line);
             }
             let gi = builder.build()?;
-            return Ok(Some(gi));
+            entries.push(GitIgnoreEntry { prefix, gi });
         }
     }
-    Ok(None)
+
+    Ok(entries)
 }
 
 /// Recursively collect JS/TS files starting from `root` respecting `.gitignore`.
@@ -27,7 +54,7 @@ pub fn collect_files(root: &VfsPath, color: bool) -> anyhow::Result<Vec<VfsPath>
         Ok(v) => v,
         Err(e) => {
             crate::log_error(color, &format!("failed to read .gitignore: {e}"));
-            None
+            Vec::new()
         }
     };
     let root_str = root.as_str().trim_end_matches('/');
@@ -68,13 +95,24 @@ pub fn collect_files(root: &VfsPath, color: bool) -> anyhow::Result<Vec<VfsPath>
         if meta.file_type != VfsFileType::File {
             continue;
         }
-        if let Some(gi) = &gitignore {
-            if gi
-                .matched_path_or_any_parents(Path::new(rel), false)
-                .is_ignore()
+        let mut ignored = false;
+        for entry in &gitignore {
+            if entry.prefix.is_empty()
+                || rel == entry.prefix
+                || rel.starts_with(&format!("{}/", entry.prefix))
             {
-                continue;
+                if entry
+                    .gi
+                    .matched_path_or_any_parents(Path::new(rel), false)
+                    .is_ignore()
+                {
+                    ignored = true;
+                    break;
+                }
             }
+        }
+        if ignored {
+            continue;
         }
         let name = Path::new(path.as_str())
             .file_name()
@@ -98,6 +136,7 @@ pub fn collect_files(root: &VfsPath, color: bool) -> anyhow::Result<Vec<VfsPath>
 mod tests {
     use super::*;
     use crate::test_util::TestFS;
+    use proptest::prelude::*;
 
     #[test]
     fn test_collect_files_respects_gitignore() {
@@ -151,5 +190,47 @@ mod tests {
             .collect();
         assert!(names.contains(&"a.js"));
         assert!(!names.contains(&"b.js"));
+    }
+
+    proptest! {
+        #[test]
+        fn prop_nested_gitignore(folder in "[a-z]{1,4}", other in "[a-z]{1,4}") {
+            prop_assume!(folder != other);
+            let entries = vec![
+                (".gitignore".to_string(), b"a.tsx\n".to_vec()),
+                (format!("{}/.gitignore", folder), b"b.tsx\n".to_vec()),
+                (format!("{}/a.tsx", folder), Vec::new()),
+                (format!("{}/b.tsx", folder), Vec::new()),
+                (format!("{}/c.tsx", folder), Vec::new()),
+                (format!("{}/a/a.tsx", folder), Vec::new()),
+                (format!("{}/a/b.tsx", folder), Vec::new()),
+                (format!("{}/a.tsx", other), Vec::new()),
+                (format!("{}/b.tsx", other), Vec::new()),
+            ];
+            let fs = TestFS::new(entries.iter().map(|(p,c)| (p.as_str(), c.as_slice())));
+            let root = fs.root();
+            let files = collect_files(&root, false).unwrap();
+            let root_str = root.as_str().trim_end_matches('/');
+            let names: Vec<String> = files
+                .iter()
+                .map(|p| p.as_str().strip_prefix(root_str).unwrap_or(p.as_str()).trim_start_matches('/') .to_string())
+                .collect();
+
+            let a1 = format!("{}/a.tsx", folder);
+            let b1 = format!("{}/b.tsx", folder);
+            let c1 = format!("{}/c.tsx", folder);
+            let aa1 = format!("{}/a/a.tsx", folder);
+            let ab1 = format!("{}/a/b.tsx", folder);
+            let a2 = format!("{}/a.tsx", other);
+            let b2 = format!("{}/b.tsx", other);
+
+            prop_assert!(!names.contains(&a1));
+            prop_assert!(!names.contains(&b1));
+            prop_assert!(names.contains(&c1));
+            prop_assert!(!names.contains(&aa1));
+            prop_assert!(!names.contains(&ab1));
+            prop_assert!(!names.contains(&a2));
+            prop_assert!(names.contains(&b2));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support multiple `.gitignore` files recursively when collecting files
- add property-based test to verify recursive `.gitignore` behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68678d76cc00833182728f8ea46b45d9