### PR TITLE
Add index parser with sameAs edges

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,7 +1,7 @@
-use crate::Node;
+use crate::{EdgeMetadata, Node};
 use petgraph::graph::{DiGraph, NodeIndex};
 
-pub fn prune_unconnected(graph: &mut DiGraph<Node, ()>) {
+pub fn prune_unconnected(graph: &mut DiGraph<Node, EdgeMetadata>) {
     loop {
         let mut removed = false;
         let nodes: Vec<NodeIndex> = graph.node_indices().collect();
@@ -30,7 +30,7 @@ mod tests {
 
     #[test]
     fn test_prune_unconnected() {
-        let mut g: DiGraph<Node, ()> = DiGraph::new();
+        let mut g: DiGraph<Node, EdgeMetadata> = DiGraph::new();
         let a = g.add_node(Node {
             name: "a".into(),
             kind: NodeKind::File,
@@ -39,7 +39,7 @@ mod tests {
             name: "b".into(),
             kind: NodeKind::File,
         });
-        g.add_edge(a, b, ());
+        g.add_edge(a, b, EdgeMetadata::default());
         let _c = g.add_node(Node {
             name: "c".into(),
             kind: NodeKind::File,

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -7,7 +7,7 @@ use crate::types::js::{
     JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
 use crate::types::{Context, Parser};
-use crate::{Node, NodeKind, ensure_folders};
+use crate::{EdgeMetadata, Node, NodeKind, ensure_folders};
 
 pub(crate) const HTML_EXTENSIONS: &[&str] = &["html"];
 
@@ -53,7 +53,8 @@ impl Parser for HtmlParser {
                 i
             };
             if data.graph.find_edge(parent_idx, file_idx).is_none() {
-                data.graph.add_edge(parent_idx, file_idx, ());
+                data.graph
+                    .add_edge(parent_idx, file_idx, EdgeMetadata::default());
             }
         }
         let re = Regex::new(r#"<script[^>]*src=[\"']([^\"']+)[\"'][^>]*>"#).unwrap();
@@ -115,7 +116,8 @@ impl Parser for HtmlParser {
                 data.nodes.insert(key, i);
                 i
             };
-            data.graph.add_edge(from_idx, to_idx, ());
+            data.graph
+                .add_edge(from_idx, to_idx, EdgeMetadata::default());
         }
         Ok(())
     }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+use vfs::VfsPath;
+
+use crate::types::{Context, Parser};
+use crate::{EdgeMetadata, NodeKind};
+
+pub struct IndexParser;
+
+impl Parser for IndexParser {
+    fn name(&self) -> &'static str {
+        "index"
+    }
+
+    fn can_parse(&self, path: &VfsPath) -> bool {
+        if let Some(name) = Path::new(path.as_str())
+            .file_name()
+            .and_then(|s| s.to_str())
+        {
+            if let Some(ext) = Path::new(name).extension().and_then(|s| s.to_str()) {
+                name.starts_with("index.") && crate::types::js::JS_EXTENSIONS.contains(&ext)
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<()> {
+        let root_str = ctx.root.as_str().trim_end_matches('/');
+        let rel = path
+            .as_str()
+            .strip_prefix(root_str)
+            .unwrap_or(path.as_str())
+            .trim_start_matches('/');
+        let parent_rel = Path::new(rel)
+            .parent()
+            .map(|p| p.to_str().unwrap())
+            .unwrap_or("");
+        let mut data = ctx.data.lock().unwrap();
+        if let (Some(&folder_idx), Some(&file_idx)) = (
+            data.nodes.get(&(parent_rel.to_string(), NodeKind::Folder)),
+            data.nodes.get(&(rel.to_string(), NodeKind::File)),
+        ) {
+            data.graph
+                .add_edge(folder_idx, file_idx, EdgeMetadata { same_as: true });
+        }
+        Ok(())
+    }
+}

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -4,7 +4,7 @@ use vfs::VfsPath;
 
 use crate::logger::log_error;
 use crate::types::{Context, Parser};
-use crate::{Node, NodeKind, ensure_folders};
+use crate::{EdgeMetadata, Node, NodeKind, ensure_folders};
 use swc_common::{FileName, SourceMap, sync::Lrc};
 use swc_ecma_ast::{Module, ModuleDecl, ModuleItem};
 use swc_ecma_parser::{EsConfig, Parser as SwcParser, StringInput, Syntax, TsConfig};
@@ -209,7 +209,8 @@ impl Parser for JsParser {
                 idx
             };
             if data.graph.find_edge(parent_idx, from_idx).is_none() {
-                data.graph.add_edge(parent_idx, from_idx, ());
+                data.graph
+                    .add_edge(parent_idx, from_idx, EdgeMetadata::default());
             }
         }
         let dir = path.parent();
@@ -269,7 +270,8 @@ impl Parser for JsParser {
                 data.nodes.insert(key, idx);
                 idx
             };
-            data.graph.add_edge(from_idx, to_idx, ());
+            data.graph
+                .add_edge(from_idx, to_idx, EdgeMetadata::default());
         }
         Ok(())
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use vfs::VfsPath;
 
-use crate::{Node, NodeKind};
+use crate::{EdgeMetadata, Node, NodeKind};
 
 #[derive(Debug)]
 pub struct GraphCtx {
-    pub graph: DiGraph<Node, ()>,
+    pub graph: DiGraph<Node, EdgeMetadata>,
     pub nodes: HashMap<(String, NodeKind), NodeIndex>,
 }
 
@@ -26,6 +26,7 @@ pub trait Parser: Send + Sync {
 }
 
 pub mod html;
+pub mod index;
 pub mod js;
 pub mod monorepo;
 pub mod package_json;

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use vfs::VfsPath;
 
 use crate::types::{Context, Parser};
-use crate::{Node, NodeKind, ensure_folders};
+use crate::{EdgeMetadata, Node, NodeKind, ensure_folders};
 
 #[derive(Deserialize)]
 struct RawPackage {
@@ -79,9 +79,11 @@ impl Parser for PackageMainParser {
                         i
                     };
                     if data.graph.find_edge(parent_idx, file_idx).is_none() {
-                        data.graph.add_edge(parent_idx, file_idx, ());
+                        data.graph
+                            .add_edge(parent_idx, file_idx, EdgeMetadata::default());
                     }
-                    data.graph.add_edge(pkg_idx, file_idx, ());
+                    data.graph
+                        .add_edge(pkg_idx, file_idx, EdgeMetadata::default());
                 }
             }
         }
@@ -148,7 +150,8 @@ impl Parser for PackageDepsParser {
                     data.nodes.insert(key, i);
                     i
                 };
-                data.graph.add_edge(pkg_idx, to_idx, ());
+                data.graph
+                    .add_edge(pkg_idx, to_idx, EdgeMetadata::default());
             } else {
                 let mut data = ctx.data.lock().unwrap();
                 let key = (dep.clone(), NodeKind::External);
@@ -162,7 +165,8 @@ impl Parser for PackageDepsParser {
                     data.nodes.insert(key, i);
                     i
                 };
-                data.graph.add_edge(pkg_idx, to_idx, ());
+                data.graph
+                    .add_edge(pkg_idx, to_idx, EdgeMetadata::default());
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- support edge metadata with new `EdgeMetadata` type
- add `IndexParser` for `index.*` files linking folder to index with metadata
- output metadata in Graphviz and JSON formats
- adjust tests and add `test_index_same_as_edge`

## Testing
- `cargo fmt -- --check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68678eeb7ea88331af1b9d6e32bd80f1