### PR TITLE
Add separate index file parser

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,7 +1,7 @@
-use crate::Node;
+use crate::{Edge, Node};
 use petgraph::graph::{DiGraph, NodeIndex};
 
-pub fn prune_unconnected(graph: &mut DiGraph<Node, ()>) {
+pub fn prune_unconnected(graph: &mut DiGraph<Node, Edge>) {
     loop {
         let mut removed = false;
         let nodes: Vec<NodeIndex> = graph.node_indices().collect();
@@ -25,12 +25,12 @@ pub fn prune_unconnected(graph: &mut DiGraph<Node, ()>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Node, NodeKind};
+    use crate::{Edge, Node, NodeKind};
     use petgraph::graph::DiGraph;
 
     #[test]
     fn test_prune_unconnected() {
-        let mut g: DiGraph<Node, ()> = DiGraph::new();
+        let mut g: DiGraph<Node, Edge> = DiGraph::new();
         let a = g.add_node(Node {
             name: "a".into(),
             kind: NodeKind::File,
@@ -39,7 +39,7 @@ mod tests {
             name: "b".into(),
             kind: NodeKind::File,
         });
-        g.add_edge(a, b, ());
+        g.add_edge(a, b, Edge::default());
         let _c = g.add_node(Node {
             name: "c".into(),
             kind: NodeKind::File,

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -53,7 +53,8 @@ impl Parser for HtmlParser {
                 i
             };
             if data.graph.find_edge(parent_idx, file_idx).is_none() {
-                data.graph.add_edge(parent_idx, file_idx, ());
+                data.graph
+                    .add_edge(parent_idx, file_idx, crate::Edge::default());
             }
         }
         let re = Regex::new(r#"<script[^>]*src=[\"']([^\"']+)[\"'][^>]*>"#).unwrap();
@@ -115,7 +116,8 @@ impl Parser for HtmlParser {
                 data.nodes.insert(key, i);
                 i
             };
-            data.graph.add_edge(from_idx, to_idx, ());
+            data.graph
+                .add_edge(from_idx, to_idx, crate::Edge::default());
         }
         Ok(())
     }

--- a/src/types/index_file.rs
+++ b/src/types/index_file.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+use vfs::VfsPath;
+
+use crate::types::js::JS_EXTENSIONS;
+use crate::types::{Context, Parser};
+use crate::{Edge, Node, NodeKind, ensure_folders};
+
+pub struct IndexFileParser;
+
+impl Parser for IndexFileParser {
+    fn name(&self) -> &'static str {
+        "index_file"
+    }
+
+    fn can_parse(&self, path: &VfsPath) -> bool {
+        match path.filename() {
+            name if name.starts_with("index.") => {
+                let ext = Path::new(path.as_str())
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                JS_EXTENSIONS.contains(&ext)
+            }
+            _ => false,
+        }
+    }
+
+    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<()> {
+        let root_str = ctx.root.as_str().trim_end_matches('/');
+        let rel = path
+            .as_str()
+            .strip_prefix(root_str)
+            .unwrap_or(path.as_str())
+            .trim_start_matches('/');
+        let mut data = ctx.data.lock().unwrap();
+        let parent_idx = ensure_folders(rel, &mut data, ctx.root_idx);
+        let key = (rel.to_string(), NodeKind::File);
+        let file_idx = if let Some(&i) = data.nodes.get(&key) {
+            i
+        } else {
+            let i = data.graph.add_node(Node {
+                name: rel.to_string(),
+                kind: NodeKind::File,
+            });
+            data.nodes.insert(key, i);
+            i
+        };
+        if let Some(eidx) = data.graph.find_edge(parent_idx, file_idx) {
+            data.graph
+                .edge_weight_mut(eidx)
+                .unwrap()
+                .metadata
+                .insert("sameAs".to_string(), "true".to_string());
+        } else {
+            let mut edge = Edge::default();
+            edge.metadata
+                .insert("sameAs".to_string(), "true".to_string());
+            data.graph.add_edge(parent_idx, file_idx, edge);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::TestFS;
+
+    #[test]
+    fn test_index_sameas_metadata() {
+        let fs = TestFS::new([("dir/index.js", ""), ("dir/other.js", "")]);
+        let root = fs.root();
+        let graph = crate::build_dependency_graph(&root, Default::default()).unwrap();
+        let folder_idx = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "dir" && graph[*i].kind == NodeKind::Folder)
+            .unwrap();
+        let index_idx = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "dir/index.js" && graph[*i].kind == NodeKind::File)
+            .unwrap();
+        let edge_idx = graph.find_edge(folder_idx, index_idx).unwrap();
+        let edge = graph.edge_weight(edge_idx).unwrap();
+        assert!(edge.metadata.contains_key("sameAs"));
+    }
+}

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -209,7 +209,8 @@ impl Parser for JsParser {
                 idx
             };
             if data.graph.find_edge(parent_idx, from_idx).is_none() {
-                data.graph.add_edge(parent_idx, from_idx, ());
+                data.graph
+                    .add_edge(parent_idx, from_idx, crate::Edge::default());
             }
         }
         let dir = path.parent();
@@ -269,7 +270,8 @@ impl Parser for JsParser {
                 data.nodes.insert(key, idx);
                 idx
             };
-            data.graph.add_edge(from_idx, to_idx, ());
+            data.graph
+                .add_edge(from_idx, to_idx, crate::Edge::default());
         }
         Ok(())
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use vfs::VfsPath;
 
-use crate::{Node, NodeKind};
+use crate::{Edge, Node, NodeKind};
 
 #[derive(Debug)]
 pub struct GraphCtx {
-    pub graph: DiGraph<Node, ()>,
+    pub graph: DiGraph<Node, Edge>,
     pub nodes: HashMap<(String, NodeKind), NodeIndex>,
 }
 
@@ -26,6 +26,7 @@ pub trait Parser: Send + Sync {
 }
 
 pub mod html;
+pub mod index_file;
 pub mod js;
 pub mod monorepo;
 pub mod package_json;

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -79,9 +79,11 @@ impl Parser for PackageMainParser {
                         i
                     };
                     if data.graph.find_edge(parent_idx, file_idx).is_none() {
-                        data.graph.add_edge(parent_idx, file_idx, ());
+                        data.graph
+                            .add_edge(parent_idx, file_idx, crate::Edge::default());
                     }
-                    data.graph.add_edge(pkg_idx, file_idx, ());
+                    data.graph
+                        .add_edge(pkg_idx, file_idx, crate::Edge::default());
                 }
             }
         }
@@ -148,7 +150,7 @@ impl Parser for PackageDepsParser {
                     data.nodes.insert(key, i);
                     i
                 };
-                data.graph.add_edge(pkg_idx, to_idx, ());
+                data.graph.add_edge(pkg_idx, to_idx, crate::Edge::default());
             } else {
                 let mut data = ctx.data.lock().unwrap();
                 let key = (dep.clone(), NodeKind::External);
@@ -162,7 +164,7 @@ impl Parser for PackageDepsParser {
                     data.nodes.insert(key, i);
                     i
                 };
-                data.graph.add_edge(pkg_idx, to_idx, ());
+                data.graph.add_edge(pkg_idx, to_idx, crate::Edge::default());
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- introduce `IndexFileParser` handling `index.*` files
- register the parser alongside existing parsers
- revert index handling from `JsParser`
- provide unit test covering the new parser

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686796ada0948331a320acc9937f44cd