### PR TITLE
Refactor parsers to be pure

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,5 @@
 use petgraph::graph::{DiGraph, NodeIndex};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use vfs::VfsPath;
 
 use crate::{Node, NodeKind};
@@ -12,17 +11,21 @@ pub struct GraphCtx {
 }
 
 pub struct Context<'a> {
-    pub data: Arc<Mutex<GraphCtx>>,
-    pub root_idx: NodeIndex,
     pub root: &'a VfsPath,
     pub aliases: &'a [(String, VfsPath)],
     pub color: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct Edge {
+    pub from: Node,
+    pub to: Node,
+}
+
 pub trait Parser: Send + Sync {
     fn name(&self) -> &'static str;
     fn can_parse(&self, path: &VfsPath) -> bool;
-    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<()>;
+    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<Vec<Edge>>;
 }
 
 pub mod html;

--- a/src/types/monorepo.rs
+++ b/src/types/monorepo.rs
@@ -1,7 +1,7 @@
 use vfs::VfsPath;
 
 use crate::types::package_util::{Package, find_packages};
-use crate::types::{Context, Parser};
+use crate::types::{Context, Edge, Parser};
 
 pub struct MonorepoParser;
 
@@ -14,9 +14,9 @@ impl Parser for MonorepoParser {
         name == "pnpm-workspace.yml" || name == "package.json"
     }
 
-    fn parse(&self, path: &VfsPath, _ctx: &Context) -> anyhow::Result<()> {
+    fn parse(&self, path: &VfsPath, _ctx: &Context) -> anyhow::Result<Vec<Edge>> {
         let _ = path.read_to_string();
-        Ok(())
+        Ok(Vec::new())
     }
 }
 


### PR DESCRIPTION
## Summary
- make parser context immutable and return `Edge` sets
- update JS, HTML and package.json parsers to build edge lists
- collect parser results when building the graph and add nodes/edges in a second pass
- adjust monorepo parser to new API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a4c4ed31483318660e70a7f7d9087