### PR TITLE
Introduce EmptyLogger for tests

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -99,7 +99,8 @@ mod tests {
         let fs = TestFS::new([("foo/bar.js", "")]);
         let root = fs.root();
 
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let folder_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "foo" && graph[*i].kind == NodeKind::Folder)
@@ -123,7 +124,8 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './style.css';"), ("style.css", "")]);
         let root = fs.root();
 
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let js_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -144,7 +146,8 @@ mod tests {
     fn test_json_output() {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));
@@ -154,7 +157,8 @@ mod tests {
     fn test_ignore_nodes() {
         let fs = TestFS::new([("a.js", ""), ("b.js", "")]);
         let root = fs.root();
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let dot = graph_to_dot(&filter_graph(
             &graph,
             true,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,17 +1,50 @@
 use colored::Colorize;
 
-pub fn log_error(color: bool, msg: &str) {
-    if color {
-        eprintln!("{}", msg.red());
-    } else {
-        eprintln!("{}", msg);
-    }
+/// Logging level for [`Logger`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogLevel {
+    Error,
+    Info,
+    Debug,
 }
 
-pub fn log_verbose(color: bool, msg: &str) {
-    if color {
-        println!("{}", msg.cyan());
-    } else {
-        println!("{}", msg);
+/// Simple logging trait.
+pub trait Logger: Send + Sync {
+    fn log(&self, level: LogLevel, msg: &str);
+}
+
+/// Logger implementation that discards all messages.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EmptyLogger;
+
+impl Logger for EmptyLogger {
+    fn log(&self, _level: LogLevel, _msg: &str) {}
+}
+
+/// Logger that writes to stdout/stderr.
+#[derive(Clone, Copy, Debug)]
+pub struct ConsoleLogger {
+    pub color: bool,
+    pub verbose: bool,
+}
+
+impl Logger for ConsoleLogger {
+    fn log(&self, level: LogLevel, msg: &str) {
+        if !self.verbose && matches!(level, LogLevel::Debug) {
+            return;
+        }
+        let output = if self.color {
+            match level {
+                LogLevel::Error => msg.red().to_string(),
+                LogLevel::Info => msg.cyan().to_string(),
+                LogLevel::Debug => msg.green().to_string(),
+            }
+        } else {
+            msg.to_string()
+        };
+        match level {
+            LogLevel::Error => eprintln!("{}", output),
+            _ => println!("{}", output),
+        }
     }
 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -31,7 +31,8 @@ mod tests {
     fn test_json_output() {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::path::Path;
 use vfs::VfsPath;
 
-use crate::logger::log_error;
+use crate::LogLevel;
 use crate::types::js::{
     JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
@@ -28,7 +28,7 @@ impl Parser for HtmlParser {
         let src = match path.read_to_string() {
             Ok(s) => s,
             Err(e) => {
-                log_error(ctx.color, &format!("failed to read {}: {e}", path.as_str()));
+                ctx.logger.log(LogLevel::Error, &format!("failed to read {}: {e}", path.as_str()));
                 return Ok(Vec::new());
             }
         };
@@ -115,7 +115,8 @@ mod tests {
             ("app.js", ""),
         ]);
         let root = fs.root();
-        let graph = build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
         let html_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.html" && graph[*i].kind == NodeKind::File)
@@ -134,7 +135,8 @@ mod tests {
             ("broken.js", ""),
         ]);
         let root = fs.root();
-        let res = build_dependency_graph(&root, Default::default());
+        let logger = crate::EmptyLogger;
+        let res = build_dependency_graph(&root, Default::default(), &logger);
         assert!(res.is_ok());
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,7 +2,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use std::collections::HashMap;
 use vfs::VfsPath;
 
-use crate::{Node, NodeKind};
+use crate::{Logger, Node, NodeKind};
 
 #[derive(Debug)]
 pub struct GraphCtx {
@@ -13,7 +13,7 @@ pub struct GraphCtx {
 pub struct Context<'a> {
     pub root: &'a VfsPath,
     pub aliases: &'a [(String, VfsPath)],
-    pub color: bool,
+    pub logger: &'a dyn Logger,
 }
 
 #[derive(Clone, Debug)]

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -124,7 +124,8 @@ mod tests {
             ("pkg/index.js", b"" as &[u8]),
         ]);
         let root = fs.root();
-        let graph = crate::build_dependency_graph(&root, Default::default()).unwrap();
+        let logger = crate::EmptyLogger;
+        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
         assert!(graph.node_indices().any(|i| graph[i].name == "pkg"));
     }
 
@@ -132,7 +133,8 @@ mod tests {
     fn test_package_parsers_malformed() {
         let fs = TestFS::new([("pkg/package.json", "not json")]);
         let root = fs.root();
-        let res = crate::build_dependency_graph(&root, Default::default());
+        let logger = crate::EmptyLogger;
+        let res = crate::build_dependency_graph(&root, Default::default(), &logger);
         assert!(res.is_ok());
     }
 
@@ -140,7 +142,8 @@ mod tests {
     fn test_malformed_package_json_is_ignored() {
         let fs = TestFS::new([("pkg/package.json", "notjson")]);
         let root = fs.root();
-        let res = crate::build_dependency_graph(&root, Default::default());
+        let logger = crate::EmptyLogger;
+        let res = crate::build_dependency_graph(&root, Default::default(), &logger);
         assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- implement `EmptyLogger` that implements the `Logger` trait and discards all messages
- re-export `EmptyLogger` from the crate
- update tests to use `EmptyLogger` instead of `ConsoleLogger`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a5e53e3b48331bce4f8cb1f6874b2