### PR TITLE
Remove BuildOptions

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -100,7 +100,7 @@ mod tests {
         let root = fs.root();
 
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let folder_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "foo" && graph[*i].kind == NodeKind::Folder)
@@ -125,7 +125,7 @@ mod tests {
         let root = fs.root();
 
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let js_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -147,7 +147,7 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));
@@ -158,7 +158,7 @@ mod tests {
         let fs = TestFS::new([("a.js", ""), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let dot = graph_to_dot(&filter_graph(
             &graph,
             true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,22 +73,18 @@ fn default_color() -> bool {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let root: VfsPath = PhysicalFS::new(&args.path).into();
-    let logger = dep::ConsoleLogger { color: args.color, verbose: args.verbose };
-    let mut graph = dep::build_dependency_graph(
-        &root,
-        dep::BuildOptions {
-            workers: args.workers,
-            verbose: args.verbose,
-            color: args.color,
-        },
-        &logger,
-    )?;
+    let logger = dep::ConsoleLogger {
+        color: args.color,
+        verbose: args.verbose,
+    };
+    let mut graph = dep::build_dependency_graph(&root, args.workers, &logger)?;
     if args.prune {
         let before = graph.node_count();
         dep::prune_unconnected(&mut graph);
-        if args.verbose {
-            logger.log(LogLevel::Debug, &format!("pruned {} nodes", before - graph.node_count()));
-        }
+        logger.log(
+            LogLevel::Debug,
+            &format!("pruned {} nodes", before - graph.node_count()),
+        );
     }
     let filtered = dep::filter_graph(
         &graph,

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -32,7 +32,7 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -88,7 +88,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
 
         let idx_index = graph
             .node_indices()
@@ -113,7 +113,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
 
         let idx_index = graph
             .node_indices()
@@ -139,7 +139,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
 
         let idx_a = graph
             .node_indices()
@@ -169,7 +169,7 @@ mod tests {
         let fs = TestFS::new([("tsconfig.json", "not json"), ("index.ts", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = build_dependency_graph(&root, Default::default(), &logger);
+        let res = build_dependency_graph(&root, None, &logger);
         assert!(res.is_ok());
     }
 }

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -116,7 +116,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = build_dependency_graph(&root, None, &logger).unwrap();
         let html_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.html" && graph[*i].kind == NodeKind::File)
@@ -136,7 +136,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = build_dependency_graph(&root, Default::default(), &logger);
+        let res = build_dependency_graph(&root, None, &logger);
         assert!(res.is_ok());
     }
 }

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -268,7 +268,7 @@ mod tests {
         let fs = TestFS::new([("a.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         assert!(graph.node_indices().any(|i| graph[i].name == "a.js"));
     }
 
@@ -277,7 +277,7 @@ mod tests {
         let fs = TestFS::new([("a.js", "import ???")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, Default::default(), &logger);
+        let res = crate::build_dependency_graph(&root, None, &logger);
         assert!(res.is_ok());
     }
 
@@ -315,7 +315,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == NodeKind::File)
@@ -337,7 +337,7 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './logo.svg';"), ("logo.svg", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         let js_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -361,7 +361,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         let main_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -383,7 +383,7 @@ mod tests {
         let fs = TestFS::new([("a.mjs", "import './b.cjs';"), ("b.cjs", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a.mjs" && graph[*i].kind == NodeKind::File)

--- a/src/types/monorepo.rs
+++ b/src/types/monorepo.rs
@@ -84,7 +84,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a" && graph[*i].kind == crate::NodeKind::Package)

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -125,7 +125,7 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, Default::default(), &logger).unwrap();
+        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
         assert!(graph.node_indices().any(|i| graph[i].name == "pkg"));
     }
 
@@ -134,7 +134,7 @@ mod tests {
         let fs = TestFS::new([("pkg/package.json", "not json")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, Default::default(), &logger);
+        let res = crate::build_dependency_graph(&root, None, &logger);
         assert!(res.is_ok());
     }
 
@@ -143,7 +143,7 @@ mod tests {
         let fs = TestFS::new([("pkg/package.json", "notjson")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, Default::default(), &logger);
+        let res = crate::build_dependency_graph(&root, None, &logger);
         assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- simplify `build_dependency_graph` API
- call `build_dependency_graph` with optional worker count throughout

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686a64f76f208331ae83c529bfa91d94