### PR TITLE
Refactor collect_files

### DIFF
--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -9,8 +9,6 @@ use crate::types::js::{
 use crate::types::{Context, Edge, Parser};
 use crate::{Node, NodeKind};
 
-pub(crate) const HTML_EXTENSIONS: &[&str] = &["html"];
-
 pub struct HtmlParser;
 
 impl Parser for HtmlParser {


### PR DESCRIPTION
## Summary
- simplify `collect_files`
- drop unused HTML/SPECIAL file handling
- expand tests for `.gitignore` rules including `node_modules`
- remove unused constant from HTML parser

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a6b38224c83319560d2b5fe6f893a