### PR TITLE
Add WalkBuilder for customizable traversal

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -100,7 +100,8 @@ mod tests {
         let root = fs.root();
 
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let folder_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "foo" && graph[*i].kind == NodeKind::Folder)
@@ -125,7 +126,8 @@ mod tests {
         let root = fs.root();
 
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let js_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -147,7 +149,8 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));
@@ -158,7 +161,8 @@ mod tests {
         let fs = TestFS::new([("a.js", ""), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let dot = graph_to_dot(&filter_graph(
             &graph,
             true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ struct Args {
     #[arg(long = "ignore-node")]
     ignore_nodes: Vec<String>,
 
+    /// File or folder patterns to ignore when scanning
+    #[arg(long = "ignore", name = "PATTERN")]
+    ignore_paths: Vec<String>,
+
     /// Output file path
     #[arg(long, default_value = "out.dot")]
     output: PathBuf,
@@ -77,7 +81,10 @@ fn main() -> anyhow::Result<()> {
         color: args.color,
         verbose: args.verbose,
     };
-    let mut graph = dep::build_dependency_graph(&root, args.workers, &logger)?;
+    let walk = dep::WalkBuilder::new(&root)
+        .ignore_patterns(&args.ignore_paths)
+        .build();
+    let mut graph = dep::build_dependency_graph(&walk, args.workers, &logger)?;
     if args.prune {
         let before = graph.node_count();
         dep::prune_unconnected(&mut graph);

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -32,7 +32,8 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let json = graph_to_json(&filter_graph(&graph, true, true, false, true, true, &[]));
         assert!(json.contains("index.js"));
         assert!(json.contains("b.js"));

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -28,7 +28,10 @@ pub fn load_tsconfig_aliases(
             let contents = match path.read_to_string() {
                 Ok(c) => c,
                 Err(e) => {
-                    logger.log(LogLevel::Error, &format!("failed to read {}: {e}", path.as_str()));
+                    logger.log(
+                        LogLevel::Error,
+                        &format!("failed to read {}: {e}", path.as_str()),
+                    );
                     return Ok(Vec::new());
                 }
             };
@@ -37,7 +40,10 @@ pub fn load_tsconfig_aliases(
                     Ok(Some(value)) => match serde_json::from_value(value) {
                         Ok(v) => v,
                         Err(e) => {
-                            logger.log(LogLevel::Error, &format!("failed to parse tsconfig.json: {e}"));
+                            logger.log(
+                                LogLevel::Error,
+                                &format!("failed to parse tsconfig.json: {e}"),
+                            );
                             return Ok(Vec::new());
                         }
                     },
@@ -45,7 +51,10 @@ pub fn load_tsconfig_aliases(
                         compiler_options: None,
                     },
                     Err(e) => {
-                        logger.log(LogLevel::Error, &format!("failed to parse tsconfig.json: {e}"));
+                        logger.log(
+                            LogLevel::Error,
+                            &format!("failed to parse tsconfig.json: {e}"),
+                        );
                         return Ok(Vec::new());
                     }
                 };
@@ -88,7 +97,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
 
         let idx_index = graph
             .node_indices()
@@ -113,7 +123,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
 
         let idx_index = graph
             .node_indices()
@@ -139,7 +150,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
 
         let idx_a = graph
             .node_indices()
@@ -169,7 +181,8 @@ mod tests {
         let fs = TestFS::new([("tsconfig.json", "not json"), ("index.ts", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = build_dependency_graph(&root, None, &logger);
+        let walk = crate::WalkBuilder::new(&root).build();
+        let res = build_dependency_graph(&walk, None, &logger);
         assert!(res.is_ok());
     }
 }

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -26,7 +26,10 @@ impl Parser for HtmlParser {
         let src = match path.read_to_string() {
             Ok(s) => s,
             Err(e) => {
-                ctx.logger.log(LogLevel::Error, &format!("failed to read {}: {e}", path.as_str()));
+                ctx.logger.log(
+                    LogLevel::Error,
+                    &format!("failed to read {}: {e}", path.as_str()),
+                );
                 return Ok(Vec::new());
             }
         };
@@ -114,7 +117,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let html_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.html" && graph[*i].kind == NodeKind::File)
@@ -134,7 +138,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = build_dependency_graph(&root, None, &logger);
+        let walk = crate::WalkBuilder::new(&root).build();
+        let res = build_dependency_graph(&walk, None, &logger);
         assert!(res.is_ok());
     }
 }

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -2,8 +2,8 @@ use regex::Regex;
 use std::path::Path;
 use vfs::VfsPath;
 
-use crate::{LogLevel, Logger};
 use crate::types::{Context, Edge, Parser};
+use crate::{LogLevel, Logger};
 use crate::{Node, NodeKind};
 use swc_common::{FileName, SourceMap, sync::Lrc};
 use swc_ecma_ast::{Module, ModuleDecl, ModuleItem};
@@ -69,7 +69,10 @@ pub(crate) fn parse_file(path: &VfsPath, logger: &dyn Logger) -> anyhow::Result<
     let src = match path.read_to_string() {
         Ok(s) => s,
         Err(e) => {
-            logger.log(LogLevel::Error, &format!("failed to read {}: {e}", path.as_str()));
+            logger.log(
+                LogLevel::Error,
+                &format!("failed to read {}: {e}", path.as_str()),
+            );
             return Ok(Vec::new());
         }
     };
@@ -268,7 +271,8 @@ mod tests {
         let fs = TestFS::new([("a.js", "import './b.js';"), ("b.js", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         assert!(graph.node_indices().any(|i| graph[i].name == "a.js"));
     }
 
@@ -277,7 +281,8 @@ mod tests {
         let fs = TestFS::new([("a.js", "import ???")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, None, &logger);
+        let walk = crate::WalkBuilder::new(&root).build();
+        let res = crate::build_dependency_graph(&walk, None, &logger);
         assert!(res.is_ok());
     }
 
@@ -315,7 +320,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == NodeKind::File)
@@ -337,7 +343,8 @@ mod tests {
         let fs = TestFS::new([("index.js", "import './logo.svg';"), ("logo.svg", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let js_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -361,7 +368,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let main_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
@@ -383,7 +391,8 @@ mod tests {
         let fs = TestFS::new([("a.mjs", "import './b.cjs';"), ("b.cjs", "")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a.mjs" && graph[*i].kind == NodeKind::File)

--- a/src/types/monorepo.rs
+++ b/src/types/monorepo.rs
@@ -1,8 +1,8 @@
 use vfs::VfsPath;
 
-use crate::types::package_util::{find_packages, Package};
-use crate::types::{Context, Edge, Parser};
 use crate::Logger;
+use crate::types::package_util::{Package, find_packages};
+use crate::types::{Context, Edge, Parser};
 
 pub struct MonorepoParser;
 
@@ -84,7 +84,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
             .find(|i| graph[*i].name == "a" && graph[*i].kind == crate::NodeKind::Package)

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -100,10 +100,20 @@ impl Parser for PackageDepsParser {
 
         for (dep, ver) in deps {
             let workspace = ver.starts_with("workspace:");
-            let kind = if workspace { NodeKind::Package } else { NodeKind::External };
+            let kind = if workspace {
+                NodeKind::Package
+            } else {
+                NodeKind::External
+            };
             edges.push(Edge {
-                from: Node { name: name.clone(), kind: NodeKind::Package },
-                to: Node { name: dep.clone(), kind },
+                from: Node {
+                    name: name.clone(),
+                    kind: NodeKind::Package,
+                },
+                to: Node {
+                    name: dep.clone(),
+                    kind,
+                },
             });
         }
         Ok(edges)
@@ -125,7 +135,8 @@ mod tests {
         ]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let graph = crate::build_dependency_graph(&root, None, &logger).unwrap();
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         assert!(graph.node_indices().any(|i| graph[i].name == "pkg"));
     }
 
@@ -134,7 +145,8 @@ mod tests {
         let fs = TestFS::new([("pkg/package.json", "not json")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, None, &logger);
+        let walk = crate::WalkBuilder::new(&root).build();
+        let res = crate::build_dependency_graph(&walk, None, &logger);
         assert!(res.is_ok());
     }
 
@@ -143,7 +155,8 @@ mod tests {
         let fs = TestFS::new([("pkg/package.json", "notjson")]);
         let root = fs.root();
         let logger = crate::EmptyLogger;
-        let res = crate::build_dependency_graph(&root, None, &logger);
+        let walk = crate::WalkBuilder::new(&root).build();
+        let res = crate::build_dependency_graph(&walk, None, &logger);
         assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- introduce `WalkBuilder` and `Walk` to configure file discovery
- ignore `.git` directories and custom patterns when collecting files
- update `build_dependency_graph` to accept a `Walk`
- wire up new builder in CLI and tests
- simplify walker by using `WalkDirIterator` and ignore `.git` by default

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686a823394948331a094ad207a319194