### PR TITLE
Add index parser and edge metadata

### DIFF
--- a/src/output/dot.rs
+++ b/src/output/dot.rs
@@ -1,7 +1,7 @@
 use petgraph::graph::DiGraph;
 use petgraph::visit::EdgeRef;
 
-use crate::{Node, NodeKind};
+use crate::{Node, NodeKind, EdgeType};
 
 fn node_attrs(kind: &NodeKind) -> (&'static str, Option<&'static str>) {
     match kind {
@@ -19,7 +19,7 @@ fn escape_label(s: &str) -> String {
 }
 
 /// Convert a dependency graph to Graphviz dot format.
-pub fn graph_to_dot(graph: &DiGraph<Node, ()>) -> String {
+pub fn graph_to_dot(graph: &DiGraph<Node, EdgeType>) -> String {
     let mut out = String::from("digraph {\n");
     for i in graph.node_indices() {
         let node = &graph[i];
@@ -37,10 +37,15 @@ pub fn graph_to_dot(graph: &DiGraph<Node, ()>) -> String {
         out.push_str("]\n");
     }
     for e in graph.edge_references() {
+        let style = match e.weight() {
+            EdgeType::SameAs => " [style=dashed]",
+            _ => "",
+        };
         out.push_str(&format!(
-            "    {} -> {}\n",
+            "    {} -> {}{}\n",
             e.source().index(),
-            e.target().index()
+            e.target().index(),
+            style
         ));
     }
     out.push_str("}\n");

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,20 +2,32 @@ use petgraph::graph::DiGraph;
 use petgraph::visit::EdgeRef;
 use serde::Serialize;
 
-use crate::Node;
+use crate::{Node, EdgeType};
+
+#[derive(Serialize)]
+struct JsonEdge {
+    from: usize,
+    to: usize,
+    #[serde(rename = "type")]
+    kind: EdgeType,
+}
 
 #[derive(Serialize)]
 struct JsonGraph {
     nodes: Vec<Node>,
-    edges: Vec<(usize, usize)>,
+    edges: Vec<JsonEdge>,
 }
 
 /// Convert a dependency graph to JSON format.
-pub fn graph_to_json(graph: &DiGraph<Node, ()>) -> String {
+pub fn graph_to_json(graph: &DiGraph<Node, EdgeType>) -> String {
     let nodes: Vec<Node> = graph.node_indices().map(|i| graph[i].clone()).collect();
-    let edges: Vec<(usize, usize)> = graph
+    let edges: Vec<JsonEdge> = graph
         .edge_references()
-        .map(|e| (e.source().index(), e.target().index()))
+        .map(|e| JsonEdge {
+            from: e.source().index(),
+            to: e.target().index(),
+            kind: e.weight().clone(),
+        })
         .collect();
     serde_json::to_string_pretty(&JsonGraph { nodes, edges }).unwrap()
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -22,11 +22,11 @@ impl std::fmt::Display for OutputType {
 pub use dot::graph_to_dot;
 pub use json::graph_to_json;
 
-use crate::Node;
+use crate::{Node, EdgeType};
 use petgraph::graph::DiGraph;
 
 /// Render the dependency graph in the requested [`OutputType`].
-pub fn graph_to_string(format: OutputType, graph: &DiGraph<Node, ()>) -> String {
+pub fn graph_to_string(format: OutputType, graph: &DiGraph<Node, EdgeType>) -> String {
     match format {
         OutputType::Dot => graph_to_dot(graph),
         OutputType::Json => graph_to_json(graph),

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -7,7 +7,7 @@ use crate::types::js::{
     JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
 use crate::types::{Context, Edge, Parser};
-use crate::{Node, NodeKind};
+use crate::{Node, NodeKind, EdgeType};
 
 pub struct HtmlParser;
 
@@ -97,6 +97,7 @@ impl Parser for HtmlParser {
             edges.push(Edge {
                 from: from_node.clone(),
                 to: to_node,
+                kind: EdgeType::Regular,
             });
         }
         Ok(edges)

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+use vfs::VfsPath;
+
+use crate::types::{Context, Edge, Parser};
+use crate::types::js::JS_EXTENSIONS;
+use crate::{Node, NodeKind, EdgeType};
+
+pub struct IndexParser;
+
+impl Parser for IndexParser {
+    fn name(&self) -> &'static str {
+        "index"
+    }
+
+    fn can_parse(&self, path: &VfsPath) -> bool {
+        let name = path.filename();
+        if let Some(ext) = Path::new(path.as_str())
+            .extension()
+            .and_then(|s| s.to_str())
+        {
+            name.starts_with("index.") && JS_EXTENSIONS.contains(&ext)
+        } else {
+            false
+        }
+    }
+
+    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<Vec<Edge>> {
+        let root_str = ctx.root.as_str().trim_end_matches('/');
+        let rel = path
+            .as_str()
+            .strip_prefix(root_str)
+            .unwrap_or(path.as_str())
+            .trim_start_matches('/');
+        let parent = path.parent();
+        let parent_rel = parent
+            .as_str()
+            .strip_prefix(root_str)
+            .unwrap_or(parent.as_str())
+            .trim_start_matches('/');
+        Ok(vec![Edge {
+            from: Node {
+                name: parent_rel.to_string(),
+                kind: NodeKind::Folder,
+            },
+            to: Node {
+                name: rel.to_string(),
+                kind: NodeKind::File,
+            },
+            kind: EdgeType::SameAs,
+        }])
+    }
+}

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -4,7 +4,7 @@ use vfs::VfsPath;
 
 use crate::types::{Context, Edge, Parser};
 use crate::{LogLevel, Logger};
-use crate::{Node, NodeKind};
+use crate::{Node, NodeKind, EdgeType};
 use swc_common::{FileName, SourceMap, sync::Lrc};
 use swc_ecma_ast::{Module, ModuleDecl, ModuleItem};
 use swc_ecma_parser::{EsConfig, Parser as SwcParser, StringInput, Syntax, TsConfig};
@@ -253,6 +253,7 @@ impl Parser for JsParser {
             edges.push(Edge {
                 from: from_node.clone(),
                 to: to_node,
+                kind: EdgeType::Regular,
             });
         }
         Ok(edges)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,11 +2,11 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use std::collections::HashMap;
 use vfs::VfsPath;
 
-use crate::{Logger, Node, NodeKind};
+use crate::{Logger, Node, NodeKind, EdgeType};
 
 #[derive(Debug)]
 pub struct GraphCtx {
-    pub graph: DiGraph<Node, ()>,
+    pub graph: DiGraph<Node, EdgeType>,
     pub nodes: HashMap<(String, NodeKind), NodeIndex>,
 }
 
@@ -20,6 +20,7 @@ pub struct Context<'a> {
 pub struct Edge {
     pub from: Node,
     pub to: Node,
+    pub kind: EdgeType,
 }
 
 pub trait Parser: Send + Sync {
@@ -30,6 +31,7 @@ pub trait Parser: Send + Sync {
 
 pub mod html;
 pub mod js;
+pub mod index;
 pub mod monorepo;
 pub mod package_json;
 pub mod package_util;

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use vfs::VfsPath;
 
 use crate::types::{Context, Edge, Parser};
-use crate::{Node, NodeKind};
+use crate::{Node, NodeKind, EdgeType};
 
 #[derive(Deserialize)]
 struct RawPackage {
@@ -60,6 +60,7 @@ impl Parser for PackageMainParser {
                             name: rel,
                             kind: NodeKind::File,
                         },
+                        kind: EdgeType::Regular,
                     });
                 }
             }
@@ -114,6 +115,7 @@ impl Parser for PackageDepsParser {
                     name: dep.clone(),
                     kind,
                 },
+                kind: EdgeType::Regular,
             });
         }
         Ok(edges)


### PR DESCRIPTION
## Summary
- add `EdgeType` with `SameAs` variant and store edges in graph
- create `IndexParser` to link folders to `index.*` files via `sameAs` edges
- include `IndexParser` when building graphs
- render `sameAs` edges as dashed in Graphviz output
- include edge `type` in JSON output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a949febbc8331b157b0b310e299cc