### PR TITLE
Add Vite glob parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub fn build_dependency_graph(
         Box::new(PackageDepsParser),
         Box::new(types::index::IndexParser),
         Box::new(types::js::JsParser),
+        Box::new(types::vite::ViteParser),
         Box::new(types::mdx::MdxParser),
         Box::new(types::html::HtmlParser),
     ];

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,3 +36,4 @@ pub mod mdx;
 pub mod monorepo;
 pub mod package_json;
 pub mod package_util;
+pub mod vite;

--- a/src/types/vite.rs
+++ b/src/types/vite.rs
@@ -1,0 +1,178 @@
+use regex::Regex;
+use std::path::Path;
+use vfs::{VfsFileType, VfsPath};
+
+use crate::types::js::JS_EXTENSIONS;
+use crate::types::{Context, Edge, Parser};
+use crate::{EdgeType, LogLevel, Node, NodeKind};
+
+fn expand_glob(base: &VfsPath, pat: &str) -> anyhow::Result<Vec<VfsPath>> {
+    let pattern = match pat.strip_prefix("./") {
+        Some(p) => glob::Pattern::new(p)?,
+        None => glob::Pattern::new(pat)?,
+    };
+    let base_str = base.as_str().trim_end_matches('/');
+    let mut matches = Vec::new();
+    let walk = match base.walk_dir() {
+        Ok(w) => w,
+        Err(e) => {
+            return Err(anyhow::anyhow!(format!("walk error: {e}")));
+        }
+    };
+    for entry in walk {
+        let path = match entry {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let meta = match path.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type != VfsFileType::File {
+            continue;
+        }
+        let rel = path
+            .as_str()
+            .strip_prefix(base_str)
+            .unwrap_or(path.as_str())
+            .trim_start_matches('/');
+        if pattern.matches(rel) {
+            matches.push(path);
+        }
+    }
+    Ok(matches)
+}
+
+pub struct ViteParser;
+
+impl Parser for ViteParser {
+    fn name(&self) -> &'static str {
+        "vite_glob"
+    }
+
+    fn can_parse(&self, path: &VfsPath) -> bool {
+        let ext = Path::new(path.as_str())
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        JS_EXTENSIONS.contains(&ext)
+    }
+
+    fn parse(&self, path: &VfsPath, ctx: &Context) -> anyhow::Result<Vec<Edge>> {
+        let src = match path.read_to_string() {
+            Ok(s) => s,
+            Err(e) => {
+                ctx.logger.log(
+                    LogLevel::Error,
+                    &format!("failed to read {}: {e}", path.as_str()),
+                );
+                return Ok(Vec::new());
+            }
+        };
+        let re = Regex::new(r#"import\.meta\.glob(?:Eager)?\(\s*['"]([^'"]+)['"]"#).unwrap();
+        let dir = path.parent();
+        let root_str = ctx.root.as_str().trim_end_matches('/');
+        let rel = path
+            .as_str()
+            .strip_prefix(root_str)
+            .unwrap_or(path.as_str())
+            .trim_start_matches('/');
+        let from_node = Node {
+            name: rel.to_string(),
+            kind: NodeKind::File,
+        };
+        let mut edges = Vec::new();
+        for cap in re.captures_iter(&src) {
+            let pattern = cap[1].to_string();
+            let Ok(files) = expand_glob(&dir, &pattern) else {
+                continue;
+            };
+            for f in files {
+                let rel_path = f
+                    .as_str()
+                    .strip_prefix(root_str)
+                    .unwrap_or(f.as_str())
+                    .trim_start_matches('/');
+                let ext = Path::new(f.as_str())
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                let kind = if JS_EXTENSIONS.contains(&ext) {
+                    NodeKind::File
+                } else {
+                    NodeKind::Asset
+                };
+                let to_node = Node {
+                    name: rel_path.to_string(),
+                    kind: kind.clone(),
+                };
+                edges.push(Edge {
+                    from: from_node.clone(),
+                    to: to_node,
+                    kind: EdgeType::Regular,
+                });
+            }
+        }
+        Ok(edges)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::TestFS;
+
+    #[test]
+    fn test_vite_glob_basic() {
+        let fs = TestFS::new([
+            (
+                "index.ts",
+                "const modules = import.meta.glob('./foo/*.jsx', { eager: true }) as any;",
+            ),
+            ("foo/a.jsx", ""),
+            ("foo/b.jsx", ""),
+        ]);
+        let root = fs.root();
+        let logger = crate::EmptyLogger;
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
+        let idx_index = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == NodeKind::File)
+            .unwrap();
+        let idx_a = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "foo/a.jsx" && graph[*i].kind == NodeKind::File)
+            .unwrap();
+        let idx_b = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "foo/b.jsx" && graph[*i].kind == NodeKind::File)
+            .unwrap();
+        assert!(graph.find_edge(idx_index, idx_a).is_some());
+        assert!(graph.find_edge(idx_index, idx_b).is_some());
+    }
+
+    #[test]
+    fn test_vite_glob_asset() {
+        let fs = TestFS::new([
+            (
+                "index.js",
+                "const imgs = import.meta.glob('./assets/*.png', { eager: true }) as any;",
+            ),
+            ("assets/logo.png", ""),
+        ]);
+        let root = fs.root();
+        let logger = crate::EmptyLogger;
+        let walk = crate::WalkBuilder::new(&root).build();
+        let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
+        let idx_index = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
+            .unwrap();
+        let idx_logo = graph
+            .node_indices()
+            .find(|i| graph[*i].name == "assets/logo.png" && graph[*i].kind == NodeKind::Asset)
+            .unwrap();
+        assert!(graph.find_edge(idx_index, idx_logo).is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- implement parser for `import.meta.glob` calls
- expose Vite parser in type modules and register it in the parser list
- add tests for dynamic glob imports

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686aa183d08c8331a3b81d07c1985477