### PR TITLE
Update parser node typing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,11 @@ fn main() -> anyhow::Result<()> {
     use std::collections::HashMap;
     let mut counts: HashMap<NodeKind, (usize, usize)> = HashMap::new();
     for idx in filtered.node_indices() {
-        let kind = filtered[idx].kind.clone();
+        let kind = filtered[idx].kind.clone().unwrap_or(NodeKind::File);
         counts.entry(kind).or_default().0 += 1;
     }
     for e in filtered.edge_references() {
-        let kind = filtered[e.source()].kind.clone();
+        let kind = filtered[e.source()].kind.clone().unwrap_or(NodeKind::File);
         counts.entry(kind).or_default().1 += 1;
     }
     let output_str = dep::output::graph_to_string(args.format, &filtered);

--- a/src/output/dot.rs
+++ b/src/output/dot.rs
@@ -2,9 +2,8 @@ use petgraph::graph::DiGraph;
 use petgraph::visit::EdgeRef;
 
 use crate::{Node, NodeKind, EdgeType};
-
-fn node_attrs(kind: &NodeKind) -> (&'static str, Option<&'static str>) {
-    match kind {
+fn node_attrs(kind: Option<&NodeKind>) -> (&'static str, Option<&'static str>) {
+    match kind.unwrap_or(&NodeKind::File) {
         NodeKind::File => ("box", None),
         NodeKind::External => ("ellipse", Some("lightblue")),
         NodeKind::Builtin => ("diamond", Some("gray")),
@@ -23,7 +22,7 @@ pub fn graph_to_dot(graph: &DiGraph<Node, EdgeType>) -> String {
     let mut out = String::from("digraph {\n");
     for i in graph.node_indices() {
         let node = &graph[i];
-        let (shape, color) = node_attrs(&node.kind);
+        let (shape, color) = node_attrs(node.kind.as_ref());
         let label = escape_label(&node.name);
         out.push_str(&format!(
             "    {} [label=\"{}\", shape={}",

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -102,11 +102,11 @@ mod tests {
 
         let idx_index = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_target = graph
             .node_indices()
-            .find(|i| graph[*i].name == "foo/bar.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "foo/bar.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(idx_index, idx_target).is_some());
     }
@@ -128,11 +128,11 @@ mod tests {
 
         let idx_index = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_target = graph
             .node_indices()
-            .find(|i| graph[*i].name == "foo/bar.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "foo/bar.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(idx_index, idx_target).is_some());
     }
@@ -155,20 +155,20 @@ mod tests {
 
         let idx_a = graph
             .node_indices()
-            .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_b = graph
             .node_indices()
-            .find(|i| graph[*i].name == "b.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "b.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_c = graph
             .node_indices()
-            .find(|i| graph[*i].name == "lib/c.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "lib/c.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
 
         let file_nodes: Vec<_> = graph
             .node_indices()
-            .filter(|i| graph[*i].kind == NodeKind::File)
+            .filter(|i| graph[*i].kind == Some(NodeKind::File))
             .collect();
         assert_eq!(file_nodes.len(), 3);
 

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -4,7 +4,7 @@ use vfs::VfsPath;
 
 use crate::LogLevel;
 use crate::types::js::{
-    JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
+    is_code_ext, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
 use crate::types::{Context, Edge, Parser};
 use crate::{Node, NodeKind, EdgeType};
@@ -59,7 +59,7 @@ impl Parser for HtmlParser {
                         .extension()
                         .and_then(|s| s.to_str())
                         .unwrap_or("");
-                    let kind = if JS_EXTENSIONS.contains(&ext) {
+                    let kind = if is_code_ext(ext) {
                         None
                     } else {
                         Some(NodeKind::Asset)
@@ -79,7 +79,7 @@ impl Parser for HtmlParser {
                     .extension()
                     .and_then(|s| s.to_str())
                     .unwrap_or("");
-                let kind = if JS_EXTENSIONS.contains(&ext) {
+                let kind = if is_code_ext(ext) {
                     None
                 } else {
                     Some(NodeKind::Asset)

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -42,7 +42,7 @@ impl Parser for HtmlParser {
         let mut edges = Vec::new();
         let from_node = Node {
             name: rel.to_string(),
-            kind: NodeKind::File,
+            kind: Some(NodeKind::File),
         };
         let re = Regex::new(r#"<script[^>]*src=[\"']([^\"']+)[\"'][^>]*>"#).unwrap();
         for cap in re.captures_iter(&src) {
@@ -60,9 +60,9 @@ impl Parser for HtmlParser {
                         .and_then(|s| s.to_str())
                         .unwrap_or("");
                     let kind = if JS_EXTENSIONS.contains(&ext) {
-                        NodeKind::File
+                        None
                     } else {
-                        NodeKind::Asset
+                        Some(NodeKind::Asset)
                     };
                     (rel, kind)
                 } else {
@@ -80,19 +80,19 @@ impl Parser for HtmlParser {
                     .and_then(|s| s.to_str())
                     .unwrap_or("");
                 let kind = if JS_EXTENSIONS.contains(&ext) {
-                    NodeKind::File
+                    None
                 } else {
-                    NodeKind::Asset
+                    Some(NodeKind::Asset)
                 };
                 (rel, kind)
             } else if is_node_builtin(&spec) {
-                (spec.clone(), NodeKind::Builtin)
+                (spec.clone(), Some(NodeKind::Builtin))
             } else {
-                (spec.clone(), NodeKind::External)
+                (spec.clone(), Some(NodeKind::External))
             };
             let to_node = Node {
                 name: target_str.clone(),
-                kind: kind.clone(),
+                kind,
             };
             edges.push(Edge {
                 from: from_node.clone(),
@@ -122,11 +122,11 @@ mod tests {
         let graph = build_dependency_graph(&walk, None, &logger).unwrap();
         let html_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.html" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.html" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let js_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "app.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "app.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(html_idx, js_idx).is_some());
     }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -40,11 +40,11 @@ impl Parser for IndexParser {
         Ok(vec![Edge {
             from: Node {
                 name: parent_rel.to_string(),
-                kind: NodeKind::Folder,
+                kind: Some(NodeKind::Folder),
             },
             to: Node {
                 name: rel.to_string(),
-                kind: NodeKind::File,
+                kind: Some(NodeKind::File),
             },
             kind: EdgeType::SameAs,
         }])

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -199,7 +199,7 @@ impl Parser for JsParser {
         let mut edges = Vec::new();
         let from_node = Node {
             name: rel.to_string(),
-            kind: NodeKind::File,
+            kind: Some(NodeKind::File),
         };
         let dir = path.parent();
         for i in imports {
@@ -216,9 +216,9 @@ impl Parser for JsParser {
                         .and_then(|s| s.to_str())
                         .unwrap_or("");
                     let kind = if JS_EXTENSIONS.contains(&ext) {
-                        NodeKind::File
+                        None
                     } else {
-                        NodeKind::Asset
+                        Some(NodeKind::Asset)
                     };
                     (rel, kind)
                 } else {
@@ -236,19 +236,19 @@ impl Parser for JsParser {
                     .and_then(|s| s.to_str())
                     .unwrap_or("");
                 let kind = if JS_EXTENSIONS.contains(&ext) {
-                    NodeKind::File
+                    None
                 } else {
-                    NodeKind::Asset
+                    Some(NodeKind::Asset)
                 };
                 (rel, kind)
             } else if is_node_builtin(&i) {
-                (i.clone(), NodeKind::Builtin)
+                (i.clone(), Some(NodeKind::Builtin))
             } else {
-                (i.clone(), NodeKind::External)
+                (i.clone(), Some(NodeKind::External))
             };
             let to_node = Node {
                 name: target_str.clone(),
-                kind: kind.clone(),
+                kind,
             };
             edges.push(Edge {
                 from: from_node.clone(),
@@ -325,15 +325,15 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "a.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let b_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "b.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "b.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let c_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "c.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "c.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(a_idx, b_idx).is_some());
         assert!(graph.find_edge(a_idx, c_idx).is_some());
@@ -348,11 +348,11 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let js_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let asset_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "logo.svg" && graph[*i].kind == NodeKind::Asset)
+            .find(|i| graph[*i].name == "logo.svg" && graph[*i].kind == Some(NodeKind::Asset))
             .unwrap();
         assert!(graph.find_edge(js_idx, asset_idx).is_some());
     }
@@ -373,15 +373,15 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let main_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let foo_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "foo.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "foo.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let bar_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "bar.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "bar.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(main_idx, foo_idx).is_some());
         assert!(graph.find_edge(main_idx, bar_idx).is_some());
@@ -396,11 +396,11 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "a.mjs" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "a.mjs" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let b_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "b.cjs" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "b.cjs" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(a_idx, b_idx).is_some());
     }

--- a/src/types/js.rs
+++ b/src/types/js.rs
@@ -11,6 +11,11 @@ use swc_ecma_parser::{EsConfig, Parser as SwcParser, StringInput, Syntax, TsConf
 
 pub(crate) const JS_EXTENSIONS: &[&str] = &["js", "jsx", "ts", "tsx", "mjs", "cjs", "mts", "cts"];
 
+/// Return true if the extension corresponds to a file type that has a parser.
+pub(crate) fn is_code_ext(ext: &str) -> bool {
+    JS_EXTENSIONS.contains(&ext) || matches!(ext, "mdx" | "html")
+}
+
 pub(crate) fn is_node_builtin(name: &str) -> bool {
     let n = name.strip_prefix("node:").unwrap_or(name);
     matches!(
@@ -215,7 +220,7 @@ impl Parser for JsParser {
                         .extension()
                         .and_then(|s| s.to_str())
                         .unwrap_or("");
-                    let kind = if JS_EXTENSIONS.contains(&ext) {
+                    let kind = if is_code_ext(ext) {
                         None
                     } else {
                         Some(NodeKind::Asset)
@@ -235,7 +240,7 @@ impl Parser for JsParser {
                     .extension()
                     .and_then(|s| s.to_str())
                     .unwrap_or("");
-                let kind = if JS_EXTENSIONS.contains(&ext) {
+                let kind = if is_code_ext(ext) {
                     None
                 } else {
                     Some(NodeKind::Asset)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,7 +7,7 @@ use crate::{EdgeType, Logger, Node, NodeKind};
 #[derive(Debug)]
 pub struct GraphCtx {
     pub graph: DiGraph<Node, EdgeType>,
-    pub nodes: HashMap<(String, NodeKind), NodeIndex>,
+    pub nodes: HashMap<(String, Option<NodeKind>), NodeIndex>,
 }
 
 pub struct Context<'a> {

--- a/src/types/monorepo.rs
+++ b/src/types/monorepo.rs
@@ -88,16 +88,16 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let a_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "a" && graph[*i].kind == crate::NodeKind::Package)
+            .find(|i| graph[*i].name == "a" && graph[*i].kind == Some(crate::NodeKind::Package))
             .unwrap();
         let b_idx = graph
             .node_indices()
-            .find(|i| graph[*i].name == "b" && graph[*i].kind == crate::NodeKind::Package)
+            .find(|i| graph[*i].name == "b" && graph[*i].kind == Some(crate::NodeKind::Package))
             .unwrap();
         let main_idx = graph
             .node_indices()
             .find(|i| {
-                graph[*i].name == "packages/a/index.js" && graph[*i].kind == crate::NodeKind::File
+                graph[*i].name == "packages/a/index.js" && graph[*i].kind == Some(crate::NodeKind::File)
             })
             .unwrap();
         assert!(graph.find_edge(a_idx, b_idx).is_some());
@@ -105,7 +105,7 @@ mod tests {
         assert!(
             graph
                 .node_indices()
-                .any(|i| graph[i].name == "ext" && graph[i].kind == crate::NodeKind::External)
-        );
+                .any(|i| graph[i].name == "ext" && graph[i].kind == Some(crate::NodeKind::External))
+            );
     }
 }

--- a/src/types/package_json.rs
+++ b/src/types/package_json.rs
@@ -54,11 +54,11 @@ impl Parser for PackageMainParser {
                     edges.push(Edge {
                         from: Node {
                             name: name.clone(),
-                            kind: NodeKind::Package,
+                            kind: Some(NodeKind::Package),
                         },
                         to: Node {
                             name: rel,
-                            kind: NodeKind::File,
+                            kind: Some(NodeKind::File),
                         },
                         kind: EdgeType::Regular,
                     });
@@ -102,14 +102,14 @@ impl Parser for PackageDepsParser {
         for (dep, ver) in deps {
             let workspace = ver.starts_with("workspace:");
             let kind = if workspace {
-                NodeKind::Package
+                Some(NodeKind::Package)
             } else {
-                NodeKind::External
+                Some(NodeKind::External)
             };
             edges.push(Edge {
                 from: Node {
                     name: name.clone(),
-                    kind: NodeKind::Package,
+                    kind: Some(NodeKind::Package),
                 },
                 to: Node {
                     name: dep.clone(),

--- a/src/types/vite.rs
+++ b/src/types/vite.rs
@@ -79,7 +79,7 @@ impl Parser for ViteParser {
             .trim_start_matches('/');
         let from_node = Node {
             name: rel.to_string(),
-            kind: NodeKind::File,
+            kind: Some(NodeKind::File),
         };
         let mut edges = Vec::new();
         for cap in re.captures_iter(&src) {
@@ -98,13 +98,13 @@ impl Parser for ViteParser {
                     .and_then(|s| s.to_str())
                     .unwrap_or("");
                 let kind = if JS_EXTENSIONS.contains(&ext) {
-                    NodeKind::File
+                    None
                 } else {
-                    NodeKind::Asset
+                    Some(NodeKind::Asset)
                 };
                 let to_node = Node {
                     name: rel_path.to_string(),
-                    kind: kind.clone(),
+                    kind,
                 };
                 edges.push(Edge {
                     from: from_node.clone(),
@@ -138,15 +138,15 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let idx_index = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.ts" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_a = graph
             .node_indices()
-            .find(|i| graph[*i].name == "foo/a.jsx" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "foo/a.jsx" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_b = graph
             .node_indices()
-            .find(|i| graph[*i].name == "foo/b.jsx" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "foo/b.jsx" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         assert!(graph.find_edge(idx_index, idx_a).is_some());
         assert!(graph.find_edge(idx_index, idx_b).is_some());
@@ -167,11 +167,11 @@ mod tests {
         let graph = crate::build_dependency_graph(&walk, None, &logger).unwrap();
         let idx_index = graph
             .node_indices()
-            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == NodeKind::File)
+            .find(|i| graph[*i].name == "index.js" && graph[*i].kind == Some(NodeKind::File))
             .unwrap();
         let idx_logo = graph
             .node_indices()
-            .find(|i| graph[*i].name == "assets/logo.png" && graph[*i].kind == NodeKind::Asset)
+            .find(|i| graph[*i].name == "assets/logo.png" && graph[*i].kind == Some(NodeKind::Asset))
             .unwrap();
         assert!(graph.find_edge(idx_index, idx_logo).is_some());
     }


### PR DESCRIPTION
## Summary
- make `Node` type optional
- only set node types for files that were parsed
- adjust graph building to reuse existing nodes when types are unknown
- update parsers and tests for optional node types

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686aa5646fdc8331be7dc0576c8274b9