### PR TITLE
refactor: centralize js helper utilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ pub fn build_dependency_graph(
 mod tests {
     use super::*;
     use crate::test_util::TestFS;
-    use crate::types::js::JS_EXTENSIONS;
+    use crate::types::util::JS_EXTENSIONS;
     use proptest::prelude::*;
 
     #[test]

--- a/src/types/html.rs
+++ b/src/types/html.rs
@@ -3,11 +3,11 @@ use std::path::Path;
 use vfs::VfsPath;
 
 use crate::LogLevel;
-use crate::types::js::{
+use crate::types::util::{
     JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
 use crate::types::{Context, Edge, Parser};
-use crate::{Node, NodeKind, EdgeType};
+use crate::{EdgeType, Node, NodeKind};
 
 pub struct HtmlParser;
 

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 use vfs::VfsPath;
 
+use crate::types::util::JS_EXTENSIONS;
 use crate::types::{Context, Edge, Parser};
-use crate::types::js::JS_EXTENSIONS;
-use crate::{Node, NodeKind, EdgeType};
+use crate::{EdgeType, Node, NodeKind};
 
 pub struct IndexParser;
 

--- a/src/types/mdx.rs
+++ b/src/types/mdx.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::path::Path;
 use vfs::VfsPath;
 
-use crate::types::js::{
+use crate::types::util::{
     JS_EXTENSIONS, is_node_builtin, resolve_alias_import, resolve_relative_import,
 };
 use crate::types::{Context, Edge, Parser};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,4 +36,5 @@ pub mod mdx;
 pub mod monorepo;
 pub mod package_json;
 pub mod package_util;
+pub mod util;
 pub mod vite;

--- a/src/types/util.rs
+++ b/src/types/util.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+use vfs::VfsPath;
+
+pub(crate) const JS_EXTENSIONS: &[&str] = &["js", "jsx", "ts", "tsx", "mjs", "cjs", "mts", "cts"];
+
+pub(crate) fn is_node_builtin(name: &str) -> bool {
+    let n = name.strip_prefix("node:").unwrap_or(name);
+    matches!(
+        n,
+        "assert"
+            | "buffer"
+            | "child_process"
+            | "cluster"
+            | "console"
+            | "constants"
+            | "crypto"
+            | "dgram"
+            | "dns"
+            | "domain"
+            | "events"
+            | "fs"
+            | "http"
+            | "https"
+            | "module"
+            | "net"
+            | "os"
+            | "path"
+            | "process"
+            | "punycode"
+            | "querystring"
+            | "readline"
+            | "repl"
+            | "stream"
+            | "string_decoder"
+            | "timers"
+            | "tls"
+            | "tty"
+            | "url"
+            | "util"
+            | "v8"
+            | "vm"
+            | "zlib"
+    )
+}
+
+pub(crate) fn resolve_relative_import(dir: &VfsPath, spec: &str) -> Option<VfsPath> {
+    if let Ok(base) = dir.join(spec) {
+        if base.exists().ok()? {
+            return Some(base);
+        }
+        let p = Path::new(spec);
+        if p.extension().is_none() {
+            for ext in JS_EXTENSIONS {
+                if let Ok(candidate) = dir.join(format!("{spec}.{}", ext)) {
+                    if candidate.exists().ok()? {
+                        return Some(candidate);
+                    }
+                }
+            }
+            for ext in JS_EXTENSIONS {
+                if let Ok(candidate) = base.join(format!("index.{}", ext)) {
+                    if candidate.exists().ok()? {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn resolve_alias_import(aliases: &[(String, VfsPath)], spec: &str) -> Option<VfsPath> {
+    for (alias, base) in aliases {
+        if spec == alias || spec.starts_with(&format!("{}/", alias)) {
+            let rest = if spec == alias {
+                ""
+            } else {
+                &spec[alias.len() + 1..]
+            };
+            if let Ok(candidate_base) = base.join(rest) {
+                if candidate_base.exists().ok()? {
+                    return Some(candidate_base);
+                }
+                let p = Path::new(rest);
+                if p.extension().is_none() {
+                    for ext in JS_EXTENSIONS {
+                        if let Ok(candidate) = base.join(format!("{rest}.{}", ext)) {
+                            if candidate.exists().ok()? {
+                                return Some(candidate);
+                            }
+                        }
+                    }
+                    for ext in JS_EXTENSIONS {
+                        if let Ok(candidate) = candidate_base.join(format!("index.{}", ext)) {
+                            if candidate.exists().ok()? {
+                                return Some(candidate);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/types/vite.rs
+++ b/src/types/vite.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::path::Path;
 use vfs::{VfsFileType, VfsPath};
 
-use crate::types::js::JS_EXTENSIONS;
+use crate::types::util::JS_EXTENSIONS;
 use crate::types::{Context, Edge, Parser};
 use crate::{EdgeType, LogLevel, Node, NodeKind};
 


### PR DESCRIPTION
## Summary
- extract shared JS helpers (extensions, alias/relative resolution, builtin detection) into new `util` module
- update parser modules to use shared utilities and expose only their `Parser` implementations

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895b05256888331928089452572c973